### PR TITLE
Enable extension for .fsx and .fsi files

### DIFF
--- a/languages/fsharp/config.toml
+++ b/languages/fsharp/config.toml
@@ -1,7 +1,7 @@
 name = "FSharp"
 code_fence_block_name = "fsharp"
 grammar = "fsharp"
-path_suffixes = ["fs"]
+path_suffixes = ["fs", "fsx", "fsi"]
 line_comments = ["// ", "/// "]
 autoclose_before = ";:.,=}])>"
 brackets = [
@@ -12,4 +12,3 @@ brackets = [
     { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
     { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },
 ]
-


### PR DESCRIPTION
Enables the extension for `fsx` and `fsi` files. These files can use the existing highlighting schema like asked for in #4. (The two other file types, `fsl` and `fsy`, mentioned in the issue have different syntax.)