### PR TITLE
README: installation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 This is a basic extension for Zed to enable F# features.
 
-# Prerequisites
+## Prerequisites
 You must have `fsautocomplete` installed, which you can do by running `dotnet tool install --global fsautocomplete`.
+
+## Installation
+
+Inside your [plugin directory](https://zed.dev/docs/extensions/installing-extensions#installation-location), run:
+
+```sh
+git clone git@github.com:nathanjcollins/zed-fsharp.git installed/fsharp
+```
+
+You can update the plugin to a pre-release version in the Zed installed plugin tab.
 
 Feel free to contribute.


### PR DESCRIPTION
It was not obvious how to install the plugin. You cannot clone it directly into `zed-fsharp`, you have to rename it to `fsharp`. 

I hope it will help future users of this nice plugin!

Cheers,
Laurent