### PR TITLE
fix: type highlighting

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "fsharp"
 name = "F#"
 description = "F# language support for Zed"
-version = "0.0.5"
+version = "0.0.6"
 schema_version = 1
 authors = ["Nathan Collins <nathjcollins@gmail.com>"]
 repository = "https://github.com/nathanjcollins/zed-fsharp"

--- a/languages/fsharp/highlights.scm
+++ b/languages/fsharp/highlights.scm
@@ -286,12 +286,13 @@
   "member"
 ] @keyword.function
 
-[
-  "enum"
-  "type"
-  "inherit"
-  "interface"
-] @keyword.type
+; commenting this out as zed seems to be doing something weird with the highlighting
+; [
+;   "enum"
+;   "type"
+;   "inherit"
+;   "interface"
+; ] @keyword.type
 
 [
   "try"
@@ -325,7 +326,10 @@
   "val"
   "module"
   "namespace"
+  "enum"
   "type"
+  "inherit"
+  "interface"
 ] @keyword
 
 (long_identifier

--- a/languages/fsharp/highlights.scm
+++ b/languages/fsharp/highlights.scm
@@ -325,6 +325,7 @@
   "val"
   "module"
   "namespace"
+  "type"
 ] @keyword
 
 (long_identifier


### PR DESCRIPTION
Fixes #9 , zed seems to be using @keyword.type differently, other @keyword categories look fine