### PR TITLE
feat: add F# outline support and bump version to 0.0.7

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "fsharp"
 name = "F#"
 description = "F# language support for Zed"
-version = "0.0.6"
+version = "0.0.7"
 schema_version = 1
 authors = ["Nathan Collins <nathjcollins@gmail.com>"]
 repository = "https://github.com/nathanjcollins/zed-fsharp"

--- a/languages/fsharp/outline.scm
+++ b/languages/fsharp/outline.scm
@@ -1,100 +1,82 @@
 ; Namespaces
-(namespace
+((namespace
   name: (long_identifier) @name) @item
-  (#set! "kind" "namespace")
+ (#set! "kind" "namespace"))
 
 ; Named modules
-(named_module
+((named_module
   name: (long_identifier) @name) @item
-  (#set! "kind" "module")
+ (#set! "kind" "module"))
 
-; Module definitions
-(module_defn
-  name: (long_identifier) @name) @item
-  (#set! "kind" "module")
+; Module definitions  
+((module_defn
+  (identifier) @name) @item
+ (#set! "kind" "module"))
 
-; Record types
-(record_type_defn
-  type_name: (type_name) @name) @item
-  (#set! "kind" "struct")
+; Type definitions - Record types
+((type_definition
+  (record_type_defn
+    (type_name (identifier) @name))) @item
+ (#set! "kind" "struct"))
 
-; Union types
-(union_type_defn
-  type_name: (type_name) @name) @item
-  (#set! "kind" "enum")
+; Type definitions - Union types
+((type_definition
+  (union_type_defn
+    (type_name (identifier) @name))) @item
+ (#set! "kind" "enum"))
 
-; Enum types
-(enum_type_defn
-  type_name: (type_name) @name) @item
-  (#set! "kind" "enum")
+; Type definitions - Enum types
+((type_definition
+  (enum_type_defn
+    (type_name (identifier) @name))) @item
+ (#set! "kind" "enum"))
 
-; Anonymous types (classes/interfaces)
-(anon_type_defn
-  type_name: (type_name) @name) @item
-  (#set! "kind" "class")
+; Type definitions - Anonymous types (classes/interfaces)
+((type_definition
+  (anon_type_defn
+    (type_name (identifier) @name))) @item
+ (#set! "kind" "class"))
 
-; Type abbreviations
-(type_abbrev_defn
-  type_name: (type_name) @name) @item
-  (#set! "kind" "type")
+; Type definitions - Type abbreviations
+((type_definition
+  (type_abbrev_defn
+    (type_name (identifier) @name))) @item
+ (#set! "kind" "type"))
 
-; Delegate types
-(delegate_type_defn
-  type_name: (type_name) @name) @item
-  (#set! "kind" "interface")
+; Type definitions - Delegate types
+((type_definition
+  (delegate_type_defn
+    (type_name (identifier) @name))) @item
+ (#set! "kind" "interface"))
 
 ; Function definitions (let bindings)
-(function_or_value_defn
-  function_declaration_left: (function_declaration_left
-    (identifier) @name)) @item
-  (#set! "kind" "function")
+((value_declaration
+  (function_or_value_defn
+    (function_declaration_left
+      (identifier) @name))) @item
+ (#set! "kind" "function"))
 
 ; Value definitions (let bindings)
-(function_or_value_defn
-  value_declaration_left: (value_declaration_left
-    (identifier_pattern
-      (long_identifier
-        (identifier) @name)))) @item
-  (#set! "kind" "variable")
+((value_declaration
+  (function_or_value_defn
+    (value_declaration_left
+      (identifier_pattern
+        (long_identifier
+          (identifier) @name))))) @item
+ (#set! "kind" "variable"))
 
-; Class methods
-(member_defn
-  method_or_prop_defn: (method_or_prop_defn
-    name: (property_or_ident
-      (identifier) @name))) @item
-  (#set! "kind" "method")
-
-; Class properties
-(member_defn
-  property_declaration: (property_declaration
-    (property_or_ident
-      (identifier) @name))) @item
-  (#set! "kind" "property")
-
-; Abstract members
-(member_defn
-  abstract_member: (abstract_member
-    name: (property_or_ident
-      (identifier) @name))) @item
-  (#set! "kind" "method")
-
-; Interface implementations
-(member_defn
-  interface_implementation: (interface_implementation
-    (type_name) @name)) @item
-  (#set! "kind" "interface")
+; Member definitions - methods and properties
+((member_defn
+  (member_signature
+    (identifier) @name)) @item
+ (#set! "kind" "method"))
 
 ; Union type cases
-(union_type_case
+((union_type_case
   (identifier) @name) @item
-  (#set! "kind" "variant")
+ (#set! "kind" "variant"))
 
 ; Enum type cases
-(enum_type_case
+((enum_type_case
   (identifier) @name) @item
-  (#set! "kind" "variant")
-
-; Record fields
-(record_field
-  (identifier) @name) @item
-  (#set! "kind" "field")
+ (#set! "kind" "variant"))

--- a/languages/fsharp/outline.scm
+++ b/languages/fsharp/outline.scm
@@ -1,0 +1,100 @@
+; Namespaces
+(namespace
+  name: (long_identifier) @name) @item
+  (#set! "kind" "namespace")
+
+; Named modules
+(named_module
+  name: (long_identifier) @name) @item
+  (#set! "kind" "module")
+
+; Module definitions
+(module_defn
+  name: (long_identifier) @name) @item
+  (#set! "kind" "module")
+
+; Record types
+(record_type_defn
+  type_name: (type_name) @name) @item
+  (#set! "kind" "struct")
+
+; Union types
+(union_type_defn
+  type_name: (type_name) @name) @item
+  (#set! "kind" "enum")
+
+; Enum types
+(enum_type_defn
+  type_name: (type_name) @name) @item
+  (#set! "kind" "enum")
+
+; Anonymous types (classes/interfaces)
+(anon_type_defn
+  type_name: (type_name) @name) @item
+  (#set! "kind" "class")
+
+; Type abbreviations
+(type_abbrev_defn
+  type_name: (type_name) @name) @item
+  (#set! "kind" "type")
+
+; Delegate types
+(delegate_type_defn
+  type_name: (type_name) @name) @item
+  (#set! "kind" "interface")
+
+; Function definitions (let bindings)
+(function_or_value_defn
+  function_declaration_left: (function_declaration_left
+    (identifier) @name)) @item
+  (#set! "kind" "function")
+
+; Value definitions (let bindings)
+(function_or_value_defn
+  value_declaration_left: (value_declaration_left
+    (identifier_pattern
+      (long_identifier
+        (identifier) @name)))) @item
+  (#set! "kind" "variable")
+
+; Class methods
+(member_defn
+  method_or_prop_defn: (method_or_prop_defn
+    name: (property_or_ident
+      (identifier) @name))) @item
+  (#set! "kind" "method")
+
+; Class properties
+(member_defn
+  property_declaration: (property_declaration
+    (property_or_ident
+      (identifier) @name))) @item
+  (#set! "kind" "property")
+
+; Abstract members
+(member_defn
+  abstract_member: (abstract_member
+    name: (property_or_ident
+      (identifier) @name))) @item
+  (#set! "kind" "method")
+
+; Interface implementations
+(member_defn
+  interface_implementation: (interface_implementation
+    (type_name) @name)) @item
+  (#set! "kind" "interface")
+
+; Union type cases
+(union_type_case
+  (identifier) @name) @item
+  (#set! "kind" "variant")
+
+; Enum type cases
+(enum_type_case
+  (identifier) @name) @item
+  (#set! "kind" "variant")
+
+; Record fields
+(record_field
+  (identifier) @name) @item
+  (#set! "kind" "field")


### PR DESCRIPTION
## Summary
- Add outline.scm file for F# code structure visualization in Zed
- Support for namespaces, modules, types, functions, and union/enum cases
- Bump extension version from 0.0.6 to 0.0.7

🤖 Generated with [Claude Code](https://claude.ai/code)