### PR TITLE
Add support for fsscript

### DIFF
--- a/languages/fsharp/config.toml
+++ b/languages/fsharp/config.toml
@@ -1,7 +1,7 @@
 name = "FSharp"
 code_fence_block_name = "fsharp"
 grammar = "fsharp"
-path_suffixes = ["fs", "fsx", "fsi"]
+path_suffixes = ["fs", "fsx", "fsi", "fsscript"]
 line_comments = ["// ", "/// "]
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
fsscript is a supported file ending for fsharp scripts (identical with .fsx)

<img width="1306" height="261" alt="Screenshot_20251114_125435" src="https://github.com/user-attachments/assets/9c540bf8-9a58-4cf1-be41-5792b494ce94" />
