### PR TITLE
feat: LSP merge user init options with defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+extension.wasm
+grammars/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 This is a basic extension for Zed to enable F# features.
 
-## Prerequisites
-You must have `fsautocomplete` installed, which you can do by running `dotnet tool install --global fsautocomplete`.
-
 ## Installation
 
 Inside your [plugin directory](https://zed.dev/docs/extensions/installing-extensions#installation-location), run:
@@ -12,5 +9,108 @@ git clone git@github.com:nathanjcollins/zed-fsharp.git installed/fsharp
 ```
 
 You can update the plugin to a pre-release version in the Zed installed plugin tab.
+
+## Configuration
+
+Settings are defined in your Zed `settings.json` (or per project in `.zed/settings.json`):
+
+Below are a list of recommended configuration settings for F# projects:
+
+### `env` 
+
+```jsonc
+{
+  "lsp": {
+    "fsautocomplete": {
+      "binary": {
+        "env": {
+          // EXPERIMENTAL: Parallel project reference resolution in FSharp.Compiler.Service
+          "FCS_ParallelReferenceResolution": "true",
+          // Server GC: better throughput for solution-wide analysis
+          "DOTNET_GCServer": "1",
+          // DATAS (.NET 8+): scales GC heaps with live data instead of one-per-core,
+          // keeping server GC's memory footprint reasonable
+          "DOTNET_GCDynamicAdaptationMode": "1"
+        }
+      }
+    }
+  }
+}
+```
+
+### `initialization_options`
+
+Allows you to pass additional initialization options to `fsautocomplete`.
+
+Your options take precedence over the default initialization options.
+
+Below is non exhaustive list of available initialization options, with their default values.
+
+```jsonc
+{
+  "lsp": {
+    "fsautocomplete": {
+      "initialization_options": {
+        "UnnecessaryParenthesesAnalyzer": true,
+        "AddPrivateAccessModifier": true,
+        "ExternalAutocomplete": false,
+        "fsac": {
+          "cachedTypeCheckCount": 200,
+        },
+        "UnusedOpensAnalyzer": true,
+        "UnusedDeclarationsAnalyzer": true,
+        "InterfaceStubGeneration": true,
+        "AbstractClassStubGeneration": true,
+        "UnionCaseStubGeneration": true,
+        "RecordStubGeneration": true,
+        "TooltipShowDocumentationLink": false,
+        // etc.
+      },
+    }
+  }
+}
+```
+
+### `fsac_custom_args`
+
+Allows you to pass additional command-line arguments to `fsautocomplete`.
+
+```jsonc
+{
+  "lsp": {
+    "fsautocomplete": {
+      "settings": {
+        "fsac_custom_args": [
+          // EXPERIMENTAL: Enable MSBuild Graph workspace loading. Should be faster than the default workspace loading
+          "--project-graph-enabled",
+          // EXPERIMENTAL: Use Transparent Compiler in FSharp.Compiler.Service. Should have better performance characteristics
+          // See https://github.com/dotnet/fsharp/pull/15179 for more details
+          "--use-fcs-transparent-compiler"
+        ]
+      }
+    }
+  }
+}
+```
+
+The arguments above are the recommended configuration.
+
+Run `fsautocomplete --help` to see all available arguments.
+
+### `fsac_custom_path`
+
+Allows you to use your own `fsautocomplete` instead of the one automatically downloaded by the extension. The path must point to `fsautocomplete.dll`, as it is run via `dotnet`.
+
+```jsonc
+{
+  "lsp": {
+    "fsautocomplete": {
+      "settings": {
+        "fsac_custom_path": "/absolute/path/to/fsautocomplete.dll"
+      }
+    }
+  }
+}
+```
 
 Feel free to contribute.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,15 @@ struct FsharpExtension {}
 #[serde(rename_all = "PascalCase")]
 struct FsAutocompleteInitOptions {
     automatic_workspace_init: bool,
+    tooltip_show_documentation_link: bool,
+    unused_opens_analyzer: bool,
+    unused_declarations_analyzer: bool,
+    add_private_access_modifier: bool,
+    external_autocomplete: bool,
+    interface_stub_generation: bool,
+    abstract_class_stub_generation: bool,
+    union_case_stub_generation: bool,
+    record_stub_generation: bool,
 }
 
 fn get_custom_args(settings_object: Option<&Map<String, Value>>) -> Vec<String> {
@@ -60,8 +69,15 @@ fn get_fsac_acquisition(
 
 fn get_final_args(fsac_path: PathBuf, custom_args: &[String]) -> Vec<String> {
     let mut final_args = vec![fsac_path.to_string_lossy().to_string()];
-    final_args.extend_from_slice(custom_args);
-    final_args.push("--adaptive-lsp-server-enabled".to_string());
+    for arg in custom_args
+        .iter()
+        .cloned()
+        .chain(std::iter::once("--adaptive-lsp-server-enabled".to_string()))
+    {
+        if !final_args.contains(&arg) {
+            final_args.push(arg);
+        }
+    }
     final_args
 }
 
@@ -112,14 +128,47 @@ impl zed::Extension for FsharpExtension {
 
     fn language_server_initialization_options(
         &mut self,
-        _language_server_id: &zed::LanguageServerId,
-        _worktree: &zed::Worktree,
+        language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
     ) -> zed::Result<Option<zed::serde_json::Value>> {
         let initialization_options = FsAutocompleteInitOptions {
             automatic_workspace_init: true,
+            // Zed does not support info panel so documentation links are not shown
+            tooltip_show_documentation_link: false,
+            unused_opens_analyzer: true,
+            unused_declarations_analyzer: true,
+            add_private_access_modifier: true,
+            external_autocomplete: false,
+            interface_stub_generation: true,
+            abstract_class_stub_generation: true,
+            union_case_stub_generation: true,
+            record_stub_generation: true,
         };
 
-        Ok(Some(serde_json::json!(initialization_options)))
+        // Defaults deep-merged with the user's lsp.fsautocomplete.initialization_options —
+        // user keys win per key, so setting one option doesn't wipe the defaults.
+        let mut options = serde_json::json!(initialization_options);
+        if let Some(user_options) = LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|settings| settings.initialization_options)
+        {
+            merge(&mut options, user_options);
+        }
+
+        Ok(Some(options))
+    }
+}
+
+/// Recursively overlay `overlay` onto `base`; objects merge per key,
+/// everything else is replaced by the overlay value.
+fn merge(base: &mut Value, overlay: Value) {
+    match (base, overlay) {
+        (Value::Object(base_map), Value::Object(overlay_map)) => {
+            for (key, value) in overlay_map {
+                merge(base_map.entry(key).or_insert(Value::Null), value);
+            }
+        }
+        (base_slot, overlay) => *base_slot = overlay,
     }
 }
 


### PR DESCRIPTION
Hello,

This PR aims to improve documentation of the project so users are aware that they can configure the extensions.

1. Add documentation with recommended configuration to improve performance (those are recommended as manually configured because they are experimental or need testing from the user to find the suit spot)
	- `env`
	- `fsac_custom_args` - 
2. Remove duplicates args from `get_final_args`
3. Add sensible default for `initialization_options` and allows user to override the settings

I will see to contribute to FSAC a documentation with the list of settings/configuration available so IDEs can reference that document as currently finding the available setting requires looking at FSAC or Ionide source code.