### PR TITLE
chore: bump version to 0.0.11

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "fsharp"
 name = "F#"
 description = "F# language support for Zed"
-version = "0.0.9"
+version = "0.0.11"
 schema_version = 1
 authors = ["Nathan Collins <me@nathancollins.dev>"]
 repository = "https://github.com/nathanjcollins/zed-fsharp"


### PR DESCRIPTION
Bumps `extension.toml` to `0.0.11` in preparation for a release.

### Why 0.0.11 and not 0.0.10

`v0.0.10` was tagged but never actually published:

- `extension.toml` at that tag still declared `0.0.9`
- the release workflow run for it failed
- the Zed registry is consequently still on `0.0.9`

Rather than re-point a tag that already exists publicly, this skips to `0.0.11`. The dud `v0.0.10` tag and its GitHub pre-release can be cleaned up separately.

### What this release will contain

Everything merged since the published `0.0.9`:

- `.fsscript` file support (#25)
- Syntax highlighting: module colour, bracket formatting, `:` as a delimiter (#28)
- LSP: sensible default `initialization_options`, deep-merged with user overrides so setting one option no longer wipes the defaults (#30)
- Docs: configuration reference for `env`, `initialization_options`, `fsac_custom_args`, `fsac_custom_path` (#30)

### Note on the release pipeline

`.github/workflows/release.yml` is currently misconfigured — `push-to` points at `nathanjcollins/zed-fsharp`, but the action expects a fork of `zed-industries/extensions`. The registry update for this release is being done manually; the workflow fix is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTxTK5HAMWFCvPcBrHftpC