### PR TITLE
chore: bump version to 0.0.12

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "fsharp"
 name = "F#"
 description = "F# language support for Zed"
-version = "0.0.11"
+version = "0.0.12"
 schema_version = 1
 authors = ["Nathan Collins <me@nathancollins.dev>"]
 repository = "https://github.com/nathanjcollins/zed-fsharp"


### PR DESCRIPTION
Bumps `extension.toml` to 0.0.12 to release #29.

#29 switches the tree-sitter grammar from `ionide/tree-sitter-fsharp` to `MangelMaxime/tree-sitter-fsharp` (pinned at `dd0f511`) and rewrites the query files against it — highlights, indents, injections, outline, brackets, plus new `overrides.scm` and `textobjects.scm`.

0.0.11 is already published in the Zed registry, pinned at `302fe30` (the commit before #29 merged), so these changes need their own version.

Once merged, tagging `v0.0.12` on main triggers `.github/workflows/release.yml`, which opens the bump PR against `zed-industries/extensions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4xhajrmmXhDhWHLrJ8o5i