### PR TITLE
fix: point release workflow at the extensions fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to release (e.g. v0.0.12)"
+        required: true
+        type: string
 
 jobs:
   homebrew:
@@ -11,6 +17,7 @@ jobs:
       - uses: huacnlee/zed-extension-action@v2
         with:
           extension-name: fsharp
-          push-to: nathanjcollins/zed-fsharp
+          push-to: nathanjcollins/zed-extensions
+          tag: ${{ inputs.tag }}
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
Every tag-triggered release has been failing within seconds — `v0.0.10` and `v0.0.12` both died the same way, and 0.0.11 had to be published by opening the registry PR by hand.

**Cause:** `zed-extension-action`'s `push-to` input is *the fork of `zed-industries/extensions`* that the action syncs and pushes a version branch to — not the extension repo. It was set to `nathanjcollins/zed-fsharp`, so the action's first write call failed:

```
POST /repos/nathanjcollins/zed-fsharp/merge-upstream - 422
##[error]HttpError: Validation Failed
```

Pointed it at `nathanjcollins/zed-extensions`, which is the actual fork of `zed-industries/extensions`.

Also adds a `workflow_dispatch` trigger with a `tag` input so a release can be re-run against an existing tag rather than deleting and re-pushing one. The action does `if (inputTag)`, so the empty value on tag pushes falls through to the pushed tag — tag-triggered runs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4xhajrmmXhDhWHLrJ8o5i